### PR TITLE
fix permissions on *nix guests

### DIFF
--- a/lib/vagrant-hostmanager/hosts_file/updater.rb
+++ b/lib/vagrant-hostmanager/hosts_file/updater.rb
@@ -42,6 +42,9 @@ module VagrantPlugins
               machine.communicate.sudo("cat /tmp/hosts > #{realhostfile}")
             else
               machine.communicate.sudo("#{move_cmd} /tmp/hosts #{realhostfile}")
+              # fix permissions
+              machine.communicate.sudo("chown root:root #{realhostfile}")
+              machine.communicate.sudo("chmod 644 #{realhostfile}")
             end
           end
 


### PR DESCRIPTION
This change changes the ownership and permissions of /etc/hosts after it is deployed, fixing issue #160 for non-Windows/SunOS guests. Not sure how those operating systems need to be handled.