### PR TITLE
Issue when local hosts file is served via NFS with root_squash.

### DIFF
--- a/lib/vagrant-hostmanager/hosts_file/updater.rb
+++ b/lib/vagrant-hostmanager/hosts_file/updater.rb
@@ -56,7 +56,12 @@ module VagrantPlugins
             copy_proc = Proc.new { windows_copy_file(file, hosts_location) }
           else
             hosts_location = '/etc/hosts'
-            copy_proc = Proc.new { `sudo cp #{file} #{hosts_location}` }
+            copy_proc = Proc.new { 
+              tmp = Tempfile.new('hosts.local')
+              FileUtils.cp(file, tmp.path())
+              `sudo cp #{tmp.path()} #{hosts_location}`
+              tmp.close!
+            }
           end
 
           FileUtils.cp(hosts_location, file)


### PR DESCRIPTION
If `hosts.local` is served via NFS with `root_squash` enabled then root cannot access the file and the line `sudo cp #{file} #{hosts_location}` fails with `cp: cannot stat: Permission denied`.