### PR TITLE
If hosts file is writable without sudo, don't use sudo

### DIFF
--- a/lib/vagrant-hostmanager/hosts_file/updater.rb
+++ b/lib/vagrant-hostmanager/hosts_file/updater.rb
@@ -56,7 +56,7 @@ module VagrantPlugins
             copy_proc = Proc.new { windows_copy_file(file, hosts_location) }
           else
             hosts_location = '/etc/hosts'
-            copy_proc = Proc.new { `sudo cp #{file} #{hosts_location}` }
+            copy_proc = Proc.new { `[ -w #{hosts_location} ] && cat #{file} > #{hosts_location} || sudo cp #{file} #{hosts_location}` }
           end
 
           FileUtils.cp(hosts_location, file)


### PR DESCRIPTION
On my machine I keep my hosts file writable by wheel so that my regular user account can modify it at a whim without having to inconveniently present my password.

This plugin didn't recognize the writability of that file and thus prompted me for a password unnecessarily.

This change uses the shell to check writability of the file and uses cat to overwrite the file (so permissions stay the same) when it can, otherwise it calls sudo as before.