### PR TITLE
Don't attempt to update machines that are not running during vagrant up

### DIFF
--- a/lib/vagrant-hostmanager/action/update_all.rb
+++ b/lib/vagrant-hostmanager/action/update_all.rb
@@ -32,7 +32,10 @@ module VagrantPlugins
             @global_env.active_machines.each do |name, p|
               if p == @provider
                 machine = @global_env.machine(name, p)
-                @updater.update_guest(machine)
+                state = machine.state
+                if state.short_description.eql? 'running'
+                  @updater.update_guest(machine)
+                end
               end
             end
           end


### PR DESCRIPTION
Fixes #200 

Currently, when running `vagrant up` after `vagrant halt` (or some other combination of steps that leaves you with powered off but provisioned vagrant machines), the hostmanager plugin will attempt to update the hostsfile on each machine. However, it does this by querying the vagrant environment for created machines. This PR changes the behavior to have hostmanager only attempt to update the hosts file on running vagrant machines during `vagrant up`.