### PR TITLE
Fix host file management for Linux and Windows hosts

### DIFF
--- a/lib/vagrant-hostmanager/hosts_file/updater.rb
+++ b/lib/vagrant-hostmanager/hosts_file/updater.rb
@@ -41,11 +41,11 @@ module VagrantPlugins
 
           if update_file(file, machine, false, line_endings)
             # upload modified file and remove temporary file
-            machine.communicate.upload(file.to_s, "/tmp/hosts/hosts.#{machine.name}")
+            machine.communicate.upload(file.to_s, "/tmp/hosts.#{machine.name}")
             if windir
-              machine.communicate.sudo("mv -force /tmp/hosts/hosts.#{machine.name} #{realhostfile}")
+              machine.communicate.sudo("mv -force /tmp/hosts.#{machine.name} #{realhostfile}")
             else
-              machine.communicate.sudo("cat /tmp/hosts > #{realhostfile}")
+              machine.communicate.sudo("cat /tmp/hosts.#{machine.name} > #{realhostfile} && rm /tmp/hosts.#{machine.name}")
             end
           end
 

--- a/lib/vagrant-hostmanager/hosts_file/updater.rb
+++ b/lib/vagrant-hostmanager/hosts_file/updater.rb
@@ -41,7 +41,7 @@ module VagrantPlugins
 
           if update_file(file, machine, false, line_endings)
             # upload modified file and remove temporary file
-            machine.communicate.upload(file.to_s, '/tmp/hosts')
+            machine.communicate.upload(file.to_s, "/tmp/hosts/hosts.#{machine.name}")
             if windir
               machine.communicate.sudo("mv -force /tmp/hosts/hosts.#{machine.name} #{realhostfile}")
             else


### PR DESCRIPTION
This PR (correctly this time!) resolves #232 #228 #231 and #229. 

My initial commit fixed windows, but broke linux and I didn't catch it during testing as I was only running hostmaster on the windows box. This morning I realized the breakage on the linux side and fixed that. Rather than creating /tmp/hosts for linux hosts I opted to just put the `hosts.#{machine.name}` directly in /tmp as on windows we're already moving it, and adding the rm for linux hosts.

I tested with 3 nodes several times to ensure this worked as expected:
RHEL7
CentOS 6
Windows 2012