### PR TITLE
Fix hang on systems with interactive rm

### DIFF
--- a/lib/vagrant-hostmanager/hosts_file/updater.rb
+++ b/lib/vagrant-hostmanager/hosts_file/updater.rb
@@ -45,7 +45,7 @@ module VagrantPlugins
             if windir
               machine.communicate.sudo("mv -force /tmp/hosts.#{machine.name} #{realhostfile}")
             else
-              machine.communicate.sudo("cat /tmp/hosts.#{machine.name} > #{realhostfile} && rm /tmp/hosts.#{machine.name}")
+              machine.communicate.sudo("cat /tmp/hosts.#{machine.name} > #{realhostfile} && rm -f /tmp/hosts.#{machine.name}")
             end
           end
 


### PR DESCRIPTION
Some systems configure `rm` to prompt when deleting a file as root
user. On such systems, hostmanager hangs when updating the hosts file
since commit 84d2f9e4be2 ("fix host file management to be windows and
linux compatible").

Avoid this by adding the '-f' parameter to rm.