### PR TITLE
Add ability to define additional entries to be added the hostfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ attribute to `true`.
 A machine's IP address is defined by either the static IP for a private
 network configuration or by the SSH host configuration. To disable
 using the private network IP address, set `config.hostmanager.ignore_private_ip`
-to true.
+to `true`.
 
 A machine's host name is defined by `config.vm.hostname`. If this is not
 set, it falls back to the symbol defining the machine in the Vagrantfile.
@@ -47,6 +47,10 @@ up or have a private ip configured will be added to the hosts file.
 In addition, the `hostmanager.aliases` configuration attribute can be used
 to provide aliases for your host names.
 
+If additional host file entries are required (for example if you are also
+running local docker instanes), set the `hostmanager.additional_hosts` attribute
+with a host entry => ip address hash.
+
 Example configuration:
 
 ```ruby
@@ -56,6 +60,7 @@ Vagrant.configure("2") do |config|
   config.hostmanager.manage_guest = true
   config.hostmanager.ignore_private_ip = false
   config.hostmanager.include_offline = true
+  config.hostmanager.additional_hosts = { 'database.local' => '127.0.0.1' }
   config.vm.define 'example-box' do |node|
     node.vm.hostname = 'example-box-hostname'
     node.vm.network :private_network, ip: '192.168.42.42'

--- a/lib/vagrant-hostmanager/config.rb
+++ b/lib/vagrant-hostmanager/config.rb
@@ -8,6 +8,7 @@ module VagrantPlugins
       attr_accessor :aliases
       attr_accessor :include_offline
       attr_accessor :ip_resolver
+      attr_accessor :additional_hosts
 
       alias_method :enabled?, :enabled
       alias_method :include_offline?, :include_offline
@@ -15,13 +16,14 @@ module VagrantPlugins
       alias_method :manage_guest?, :manage_guest
 
       def initialize
-        @enabled            = UNSET_VALUE
-        @manage_host        = UNSET_VALUE
-        @manage_guest       = UNSET_VALUE
-        @ignore_private_ip  = UNSET_VALUE
-        @include_offline    = UNSET_VALUE
-        @aliases            = UNSET_VALUE
-        @ip_resolver        = UNSET_VALUE
+        @enabled               = UNSET_VALUE
+        @manage_host           = UNSET_VALUE
+        @manage_guest          = UNSET_VALUE
+        @ignore_private_ip     = UNSET_VALUE
+        @include_offline       = UNSET_VALUE
+        @aliases               = UNSET_VALUE
+        @ip_resolver           = UNSET_VALUE
+        @additional_hosts      = UNSET_VALUE
       end
 
       def finalize!
@@ -32,6 +34,7 @@ module VagrantPlugins
         @include_offline    = false if @include_offline == UNSET_VALUE
         @aliases            = [] if @aliases == UNSET_VALUE
         @ip_resolver        = nil if @ip_resolver == UNSET_VALUE
+        @additional_hosts   = {} if @additional_hosts == UNSET_VALUE
 
         @aliases = [ @aliases ].flatten
       end
@@ -52,6 +55,14 @@ module VagrantPlugins
           errors << I18n.t('vagrant_hostmanager.config.not_an_array_or_string', {
             :config_key => 'hostmanager.aliases',
             :is_class   => aliases.class.to_s,
+          })
+        end
+
+        # Check if the additional hosts is a Hash
+        if  !additional_hosts.kind_of?(Hash)
+          errors << I18n.t('vagrant_hostmanager.config.not_a_hash', {
+            :config_key => 'hostmanager.additional_hosts',
+            :is_class   => additional_hosts.class.to_s,
           })
         end
 

--- a/lib/vagrant-hostmanager/hosts_file/updater.rb
+++ b/lib/vagrant-hostmanager/hosts_file/updater.rb
@@ -92,7 +92,7 @@ module VagrantPlugins
           footer = "## vagrant-hostmanager-end\n"
           body = get_machines
             .map { |machine| get_hosts_file_entry(machine, resolving_machine) }
-            .join
+            .flatten.uniq.join("\n") + "\n"
           get_new_content(header, footer, body, file_content, line_endings)
         end
 
@@ -100,10 +100,19 @@ module VagrantPlugins
           ip = get_ip_address(machine, resolving_machine)
           host = machine.config.vm.hostname || machine.name
           aliases = machine.config.hostmanager.aliases
+          additional_hosts = machine.config.hostmanager.additional_hosts
+
+          host_file_entry_list = []
           if ip != nil
-            "#{ip}\t#{host}\n" + aliases.map{|a| "#{ip}\t#{a}"}.join("\n") + "\n"
+            host_file_entry_list = ["#{ip}\t#{host}", aliases.map{|a| "#{ip}\t#{a}"}]
           end
-        end
+
+          additional_hosts.each do |host_name, ip_addr|
+            host_file_entry_list.push("#{ip_addr}\t#{host_name}")
+          end
+
+          host_file_entry_list
+      end
 
         def get_ip_address(machine, resolving_machine)
           custom_ip_resolver = machine.config.hostmanager.ip_resolver

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,3 +8,4 @@ en:
       not_a_bool: "[vagrant-hostmanager:config:error] A value for %{config_key} can only be true or false, not type '%{value}'"
       not_an_array_or_string: "[vagrant-hostmanager:config:error] A value for %{config_key} must be an Array or String, not type '%{is_class}'"
       not_a_proc: "[vagrant-hostmanager:config:error] A value for %{config_key} must be a Proc, not type '%{is_class}'"
+      not_a_hash: "[vagrant-hostmanager:config:error] A value for %{config_key} must be a Hash, not type '%{is_class}'"


### PR DESCRIPTION
I needed to be able to manage additional hostfile entries when running a multi-machine vagrantfile that contained both virtualbox and docker containers (managed by docker-compose).